### PR TITLE
exempt Dependabot from the version-bump gate

### DIFF
--- a/.github/workflows/check-version-update-pull-request.yml
+++ b/.github/workflows/check-version-update-pull-request.yml
@@ -14,7 +14,13 @@ jobs:
         with:
           file-url: https://raw.githubusercontent.com/${{ github.event.pull_request.base.repo.full_name }}/${{ github.event.pull_request.base.ref }}/package.json
           static-checking: localIsNew
+      # Dependabot cannot bump `version` — it only ever edits package.json's dependency
+      # ranges — so without this exemption every Dependabot PR fails this gate and its
+      # updates silently pile up as open alerts instead of landing. Keyed on who OPENED
+      # the PR rather than `github.actor`, which changes when a human pushes to the
+      # branch or re-runs the job. The check step above still runs and reports, so a
+      # Dependabot PR shows the version as unchanged without that being fatal.
       - name: Fail when unchanged
-        if: steps.version-check.outputs.changed == 'false'
+        if: steps.version-check.outputs.changed == 'false' && github.event.pull_request.user.login != 'dependabot[bot]'
         run: 'echo "No version change detected. Please update the version in package.json." && exit 1'
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elifoot98_web",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "author": "Leonardo Pereira <jlcvp>",
   "homepage": "https://www.elifoot98.com.br",
   "repository": {


### PR DESCRIPTION
## Problem

`check-version-update-pull-request.yml` fails any PR to `main` whose `package.json`
`version` is unchanged. Dependabot only ever edits dependency ranges — it has no way to
bump `version` — so **every Dependabot PR fails this gate and none of them can land.**
Its updates accumulate as open alerts instead of arriving as merged PRs.

## Change

Gate the failure step on the PR author:

```yaml
if: steps.version-check.outputs.changed == 'false' && github.event.pull_request.user.login != 'dependabot[bot]'
```

Two deliberate choices:

- **Gate the step, not the job.** A job-level `if` would skip the whole check, which means
  relying on GitHub treating a skipped required check as passing. Gating the failure step
  instead keeps the job running and reporting on Dependabot PRs — it just isn't fatal.
- **`github.event.pull_request.user.login`, not `github.actor`.** The actor changes when a
  human pushes to the branch or re-runs the job, which would silently re-arm the gate
  partway through a PR. The PR author does not change.

The gate is unchanged for human PRs.

## Verification

`.github/workflows/check-version-update-pull-request.yml` parses as valid YAML with 3 steps
and the expected condition on the final one. Behaviour on a real Dependabot PR can only be
confirmed once one opens — worth watching the next one.

## Note on merge order

This bumps `version` to **2.1.5**. The companion browserslist PR bumps to **2.1.6** and
assumes this one merges first. Merging them in the other order leaves that PR's version no
longer newer than `main`'s, and its own gate will fail.
