### PR TITLE
raise the Safari/iOS browserslist floor to 14.1/14.5

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -8,9 +8,16 @@
 # You can see what browsers were selected by your queries by running:
 #   npx browserslist
 
+# Safari/iOS floors are 14.1/14.5, not 14.0, and that is deliberate: esbuild >=0.25.12
+# refuses to transform destructuring for a safari14.0 target rather than emit output it
+# believes is broken, which fails the build with hundreds of "Transforming destructuring
+# to the configured target environment is not supported yet" errors. Every current Angular
+# line pins an esbuild past that boundary (19.2.27 -> 0.28.0, 20.3.35 -> 0.28.1,
+# 22.1.6 -> 0.28.2), so raising the floor is a prerequisite for any dependency update, not
+# a preference. Bisected: 14/14 -> 764 errors, 14.1/14.5 -> 0.
 Chrome >=79
 ChromeAndroid >=79
 Firefox >=70
 Edge >=79
-Safari >=14
-iOS >=14
+Safari >=14.1
+iOS >=14.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elifoot98_web",
-  "version": "2.1.4",
+  "version": "2.1.6",
   "author": "Leonardo Pereira <jlcvp>",
   "homepage": "https://www.elifoot98.com.br",
   "repository": {


### PR DESCRIPTION
## Problem

`esbuild` >= 0.25.12 **refuses** to transform destructuring for a `safari14.0` target —
it errors rather than emit output it believes is broken:

```
Transforming destructuring to the configured target environment
("chrome79.0", "edge79.0", "firefox70.0", "ios14.0", "safari14.0") is not supported yet
```

`.browserslistrc` declares `Safari >=14` / `iOS >=14`, so any dependency update that moves
`@angular/build` forward fails the build with 764 of these errors. Every current Angular
line pins an esbuild past that boundary:

| `@angular/build` | esbuild |
|---|---|
| 19.2.19 (current lockfile) | 0.25.4 — OK |
| 19.2.27 | 0.28.0 — fails |
| 20.3.35 / 21.2.22 | 0.28.1 — fails |
| 22.1.6 | 0.28.2 — fails |

**The stale lockfile is the only reason the build works today.** This is a prerequisite for
updating dependencies at all, not a preference.

## Change

```diff
-Safari >=14
-iOS >=14
+Safari >=14.1
+iOS >=14.5
```

Bisected on this repo, cache cleared between runs: `14`/`14` → 764 errors;
**`14.1`/`14.5` → 0**; `>=15` → 0; `>=16.4` → 0; deleting the file → 0. Chose the lowest
floor that builds.

## What it costs: nothing that ships today

On paper this drops two browsers. Verified with `npx browserslist` before and after — the
**only** entries removed are `safari 14` and `ios_saf 14.0-14.4`. Nothing else changes.

In practice it drops nothing right now. Built before and after against the current
lockfile:

- exit 0 both times, zero destructuring errors
- **70 of 71 content-hashed output files are byte-identical**
- `main.js` is identical in size (578,624 bytes) and differs only in hash, because
  `prebuild` stamps the build date into `src/environments`

So no user receives different code from this commit. Its entire value is unblocking the
dependency update that follows. The support drop only becomes materially real if a future
esbuild changes how it lowers for the 14.1 target.

Worth noting the file has been over-promising regardless: Angular's own build warns that
everything from `chrome 79` through `safari 14.1` falls outside the framework's supported
browsers, so these floors were already below what Angular itself claims to support.

## Verification

- `npm ci` against `main`'s lockfile, then `npm run build` — exit 0, no errors
- output compared file-by-file before/after (see above)
- `src/environments` restored after each build per the version-stamping gotcha in CLAUDE.md

No automated coverage exists for the js-dos boot chain (the four-pixel load detector and
the tesseract auto-save OCR are invisible to lint and build), but since the emitted bundle
is byte-identical, there is nothing here that could affect them.

## Note on merge order

This bumps `version` to **2.1.6** and assumes the Dependabot CI-gate PR (2.1.5) merges
first. In the other order, this version is no longer newer than `main`'s and its own gate
fails.
